### PR TITLE
Update sprite sizes and fix metagame capitalization

### DIFF
--- a/adv-ou/css/layout.css
+++ b/adv-ou/css/layout.css
@@ -140,7 +140,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 48px;
+  height: 64px;
 }
 
 .pokemon-mini-sprite img {

--- a/adv-ou/index.html
+++ b/adv-ou/index.html
@@ -329,7 +329,7 @@
             const key = getPokemonKeyByName(name);
             const style = getTypeStyle(name);
             const onclick = key ? `onclick="showPokemonDetail('${key}')"` : '';
-            const spriteHtml = showSprite ? createSprite(name, 24) : '';
+            const spriteHtml = showSprite ? createSprite(name, 36) : '';
             return `<span class="pokemon-badge" ${onclick} style="background: ${style.gradient}; color: ${style.textColor}; cursor: ${key ? 'pointer' : 'default'}; text-shadow: ${style.textColor === '#000000' ? 'none' : '1px 1px 2px rgba(0,0,0,0.5)'};">${spriteHtml}<span class="pokemon-badge-name">${name}</span></span>`;
         }
 
@@ -397,7 +397,7 @@
                         <div class="pokemon-grid">
                             ${tiers[tier].map(mon => `
                                 <div class="pokemon-mini" onclick="showPokemonDetail('${mon.key}')">
-                                    <div class="pokemon-mini-sprite">${createSprite(mon.name, 48)}</div>
+                                    <div class="pokemon-mini-sprite">${createSprite(mon.name, 64)}</div>
                                     <strong class="pokemon-mini-name">${mon.name}</strong>
                                     <div class="pokemon-mini-types">
                                         ${mon.types.map(t => `<span class="type-badge type-${t.toLowerCase()}">${t}</span>`).join(' ')}
@@ -505,7 +505,7 @@
                     <h2>Clauses</h2>
                     <ul class="mt-3">
                         ${Object.entries(meta.clauses || {}).map(([k, v]) =>
-                            `<li class="mb-2"><strong>${k.replace(/_/g, ' ')}:</strong> <span class="text-secondary">${v}</span></li>`
+                            `<li class="mb-2"><strong>${k.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}:</strong> <span class="text-secondary">${v}</span></li>`
                         ).join('')}
                     </ul>
                 </div>
@@ -658,7 +658,7 @@
                             <h4>${team.name}</h4>
                             <p class="text-secondary text-sm">by ${team.author} (${team.year})</p>
                             <div class="sprite-grid mt-3 mb-3">
-                                ${team.team.map(p => createSpriteOnly(p, 40)).join('')}
+                                ${team.team.map(p => createSpriteOnly(p, 56)).join('')}
                             </div>
                             <p>${team.description}</p>
                             ${team.key_features ? `


### PR DESCRIPTION
- Increase Pokemon badge sprites from 24px to 36px
- Increase Pokemon grid card sprites from 48px to 64px
- Increase sample teams sprite grid from 40px to 56px
- Fix clause capitalization (sleep clause → Sleep Clause)