### PR TITLE
Add interconnected Cores/Archetypes/Teams navigation system

### DIFF
--- a/adv-ou/css/layout.css
+++ b/adv-ou/css/layout.css
@@ -109,8 +109,8 @@
 }
 
 .info-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  display: flex;
+  flex-direction: column;
   gap: var(--space-4);
 }
 

--- a/adv-ou/index.html
+++ b/adv-ou/index.html
@@ -52,6 +52,46 @@
             font-weight: var(--font-weight-semibold);
             color: var(--color-electric);
         }
+
+        /* Highlight effect for navigation */
+        .highlight {
+            animation: highlightPulse 2s ease-out;
+        }
+
+        @keyframes highlightPulse {
+            0% { box-shadow: 0 0 0 4px var(--color-sapphire); }
+            100% { box-shadow: none; }
+        }
+
+        /* Link tags for cores/archetypes */
+        .link-tag {
+            display: inline-block;
+            font-family: var(--font-mono);
+            font-size: var(--text-xs);
+            padding: var(--space-1) var(--space-2);
+            margin: 2px;
+            border-radius: var(--radius-sm);
+            background: var(--color-bg-primary);
+            border: 1px solid var(--color-sapphire);
+            color: var(--color-sapphire);
+            cursor: pointer;
+            transition: all var(--transition-fast);
+        }
+
+        .link-tag:hover {
+            background: var(--color-sapphire);
+            color: white;
+        }
+
+        .link-tag.team-link {
+            border-color: var(--color-emerald);
+            color: var(--color-emerald);
+        }
+
+        .link-tag.team-link:hover {
+            background: var(--color-emerald);
+            color: white;
+        }
     </style>
 </head>
 <body>
@@ -59,8 +99,8 @@
     <nav class="nav-tabs">
         <a href="#" class="nav-tab active" data-section="pokemon">Pokemon</a>
         <a href="#" class="nav-tab" data-section="metagame">Metagame</a>
-        <a href="#" class="nav-tab" data-section="archetypes">Archetypes</a>
         <a href="#" class="nav-tab" data-section="cores">Cores</a>
+        <a href="#" class="nav-tab" data-section="archetypes">Archetypes</a>
         <a href="#" class="nav-tab" data-section="teams">Sample Teams</a>
         <a href="#" class="nav-tab" data-section="speed">Speed Tiers</a>
         <a href="#" class="nav-tab" data-section="calculator">Calculator</a>
@@ -80,14 +120,14 @@
             <div id="metagame-content"></div>
         </section>
 
-        <!-- Archetypes Section -->
-        <section id="archetypes" class="section">
-            <div id="archetypes-content"></div>
-        </section>
-
         <!-- Cores Section -->
         <section id="cores" class="section">
             <div id="cores-content"></div>
+        </section>
+
+        <!-- Archetypes Section -->
+        <section id="archetypes" class="section">
+            <div id="archetypes-content"></div>
         </section>
 
         <!-- Sample Teams Section -->
@@ -393,6 +433,135 @@
             </div>`;
         }
 
+        // =========================
+        // Linking Functions
+        // =========================
+
+        // Find archetypes that contain ALL of the given Pokemon
+        function findArchetypesForCore(corePokemon) {
+            const archetypes = metagameData.archetypes || {};
+            const matches = [];
+
+            Object.entries(archetypes).forEach(([key, arch]) => {
+                const archPokemon = arch.key_pokemon || [];
+                // Check if all core Pokemon are in this archetype
+                const allFound = corePokemon.every(cp =>
+                    archPokemon.some(ap => ap.toLowerCase() === cp.toLowerCase())
+                );
+                if (allFound) {
+                    matches.push({ key, name: arch.name });
+                }
+            });
+
+            return matches;
+        }
+
+        // Find teams that match an archetype based on key features or archetype name
+        function findTeamsForArchetype(archetypeKey, archetypeName) {
+            const teams = sampleTeamsData.sample_teams || {};
+            const matches = [];
+
+            Object.entries(teams).forEach(([archKey, archetype]) => {
+                // Check if archetype name matches
+                const archLower = archetypeName.toLowerCase();
+                const teamArchLower = archetype.archetype.toLowerCase();
+
+                archetype.teams.forEach(team => {
+                    const keyFeatures = (team.key_features || []).map(f => f.toLowerCase());
+                    const teamName = team.name.toLowerCase();
+
+                    // Match by archetype name similarity or key features
+                    const isMatch =
+                        teamArchLower.includes(archLower.split(' ')[0]) ||
+                        archLower.includes(teamArchLower.split(' ')[0]) ||
+                        keyFeatures.some(f => f.includes(archLower.split(' ')[0])) ||
+                        teamName.includes(archLower.split(' ')[0]);
+
+                    if (isMatch) {
+                        matches.push({
+                            teamName: team.name,
+                            archetype: archetype.archetype,
+                            author: team.author
+                        });
+                    }
+                });
+            });
+
+            return matches;
+        }
+
+        // Find cores that match a key feature
+        function findCoreByFeature(feature) {
+            const cores = metagameData.key_cores || {};
+            const featureLower = feature.toLowerCase();
+
+            for (const [key, core] of Object.entries(cores)) {
+                const coreName = core.pokemon.join('').toLowerCase().replace(/\s/g, '');
+                const featureClean = featureLower.replace(/\s/g, '');
+
+                if (coreName.includes(featureClean) || featureClean.includes(coreName) ||
+                    key.toLowerCase().includes(featureClean)) {
+                    return { key, core };
+                }
+            }
+            return null;
+        }
+
+        // Find archetype that matches a key feature
+        function findArchetypeByFeature(feature) {
+            const archetypes = metagameData.archetypes || {};
+            const featureLower = feature.toLowerCase();
+
+            for (const [key, arch] of Object.entries(archetypes)) {
+                const archName = arch.name.toLowerCase();
+                if (archName.includes(featureLower) || featureLower.includes(archName.split(' ')[0])) {
+                    return { key, archetype: arch };
+                }
+            }
+            return null;
+        }
+
+        // Navigate to a specific tab and scroll to element
+        function navigateToSection(tabId, elementId = null) {
+            // Switch tab
+            document.querySelectorAll('.nav-tab').forEach(t => t.classList.remove('active'));
+            document.querySelectorAll('.section').forEach(s => s.classList.remove('active'));
+
+            document.querySelector(`[data-section="${tabId}"]`).classList.add('active');
+            document.getElementById(tabId).classList.add('active');
+
+            window.scrollTo(0, 0);
+
+            // Highlight element if specified
+            if (elementId) {
+                setTimeout(() => {
+                    const el = document.getElementById(elementId);
+                    if (el) {
+                        el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                        el.classList.add('highlight');
+                        setTimeout(() => el.classList.remove('highlight'), 2000);
+                    }
+                }, 100);
+            }
+        }
+
+        // Handle key feature click
+        function handleFeatureClick(feature) {
+            // Try to find a matching core
+            const coreMatch = findCoreByFeature(feature);
+            if (coreMatch) {
+                navigateToSection('cores', `core-${coreMatch.key}`);
+                return;
+            }
+
+            // Try to find a matching archetype
+            const archMatch = findArchetypeByFeature(feature);
+            if (archMatch) {
+                navigateToSection('archetypes', `archetype-${archMatch.key}`);
+                return;
+            }
+        }
+
         // Load JSON data
         async function loadData() {
             try {
@@ -620,8 +789,11 @@
             let html = '<div class="info-grid">';
 
             Object.entries(archetypes).forEach(([key, arch]) => {
+                // Find teams that use this archetype
+                const relatedTeams = findTeamsForArchetype(key, arch.name);
+
                 html += `
-                    <div class="card">
+                    <div class="card" id="archetype-${key}">
                         <h2 class="card-title">${arch.name}</h2>
                         <p class="text-secondary mb-4">${arch.description}</p>
                         <h3 class="section-subheader mt-4">Key Pokemon</h3>
@@ -631,6 +803,12 @@
                         <h3 class="section-subheader">Gameplan</h3>
                         <p class="card-body">${arch.gameplan}</p>
                         ${arch.notes ? `<p class="text-secondary mt-3" style="font-style: italic;">${arch.notes}</p>` : ''}
+                        ${relatedTeams.length > 0 ? `
+                            <h3 class="section-subheader">Sample Teams</h3>
+                            <div class="moves-list">
+                                ${relatedTeams.slice(0, 5).map(t => `<span class="link-tag team-link" onclick="navigateToSection('teams')">${t.teamName}</span>`).join('')}
+                            </div>
+                        ` : ''}
                     </div>
                 `;
             });
@@ -647,19 +825,38 @@
             let html = '<div class="info-grid">';
 
             Object.entries(cores).forEach(([key, core]) => {
+                // Find archetypes that use this core
+                const relatedArchetypes = findArchetypesForCore(core.pokemon);
+
                 html += `
-                    <div class="core-card">
-                        <div class="core-header">
-                            <div class="core-pokemon-pair">
-                                ${core.pokemon.map(p => createPokemonBadge(p)).join('<span class="core-plus">+</span>')}
-                            </div>
+                    <div class="card" id="core-${key}">
+                        <div class="flex justify-between items-start mb-3">
+                            <h2 class="card-title">${core.pokemon.join(' + ')}</h2>
                             <span class="archetype-badge ${core.type === 'Offensive' ? 'offensive' : core.type === 'Defensive' ? 'defensive' : 'balanced'}">${core.type}</span>
                         </div>
-                        <p class="core-description">${core.description}</p>
-                        ${core.synergy ? `<p class="text-sm"><span class="font-semibold text-emerald">Synergy:</span> ${core.synergy}</p>` : ''}
-                        ${core.strategy ? `<p class="text-sm mt-2"><span class="font-semibold text-sapphire">Strategy:</span> ${core.strategy}</p>` : ''}
-                        ${core.notes ? `<p class="text-sm text-secondary mt-2"><span class="font-medium">Notes:</span> ${core.notes}</p>` : ''}
-                        ${core.weaknesses ? `<p class="core-weaknesses mt-3"><strong>Weaknesses:</strong> ${core.weaknesses.join(', ')}</p>` : ''}
+                        <div class="moves-list mb-4">
+                            ${core.pokemon.map(p => createPokemonBadge(p)).join('')}
+                        </div>
+                        <p class="text-secondary mb-4">${core.description}</p>
+                        ${core.synergy ? `
+                            <h3 class="section-subheader mt-4">Synergy</h3>
+                            <p class="card-body">${core.synergy}</p>
+                        ` : ''}
+                        ${core.strategy ? `
+                            <h3 class="section-subheader">Strategy</h3>
+                            <p class="card-body">${core.strategy}</p>
+                        ` : ''}
+                        ${core.notes ? `<p class="text-secondary mt-3" style="font-style: italic;">${core.notes}</p>` : ''}
+                        ${core.weaknesses ? `
+                            <h3 class="section-subheader">Weaknesses</h3>
+                            <p class="text-ruby">${core.weaknesses.join(', ')}</p>
+                        ` : ''}
+                        ${relatedArchetypes.length > 0 ? `
+                            <h3 class="section-subheader">Used In Archetypes</h3>
+                            <div class="moves-list">
+                                ${relatedArchetypes.map(a => `<span class="link-tag" onclick="navigateToSection('archetypes', 'archetype-${a.key}')">${a.name}</span>`).join('')}
+                            </div>
+                        ` : ''}
                     </div>
                 `;
             });
@@ -717,7 +914,7 @@
                             ${team.key_features ? `
                                 <p class="mt-3 font-semibold">Key Features:</p>
                                 <div class="moves-list">
-                                    ${team.key_features.map(f => `<span class="move-badge">${f}</span>`).join('')}
+                                    ${team.key_features.map(f => `<span class="link-tag" onclick="handleFeatureClick('${f.replace(/'/g, "\\'")}')">${f}</span>`).join('')}
                                 </div>
                             ` : ''}
                             ${team['2024_trends'] ? `<p class="mt-3 text-secondary" style="font-style: italic;"><strong>2024 Trends:</strong> ${team['2024_trends']}</p>` : ''}


### PR DESCRIPTION
Tab & Layout Changes:
- Reorder tabs: Cores → Archetypes → Sample Teams
- Make Cores and Archetypes single column layout (no horizontal grid)
- Update both to use consistent card formatting

Linking System:
- Add findArchetypesForCore() - finds archetypes containing core Pokemon
- Add findTeamsForArchetype() - finds teams matching archetype
- Add findCoreByFeature() and findArchetypeByFeature() for key features
- Add navigateToSection() with highlight animation
- Add handleFeatureClick() for key feature navigation

Core Cards:
- Show "Used In Archetypes" section with clickable tags
- Tags navigate to and highlight the matching archetype

Archetype Cards:
- Show "Sample Teams" section with clickable tags
- Tags navigate to the Sample Teams tab

Sample Teams Key Features:
- Key features are now clickable link-tags
- Clicking navigates to matching Core or Archetype

New CSS:
- .link-tag and .link-tag.team-link styles
- .highlight animation for navigation feedback