### PR TITLE
Enhance Speed Tiers page with visualizations

### DIFF
--- a/adv-ou/index.html
+++ b/adv-ou/index.html
@@ -143,6 +143,148 @@
             box-shadow: 0 0 12px rgba(69, 123, 157, 0.4);
         }
 
+        /* Fixed-width Pokemon badges for speed tiers */
+        .pokemon-badge-fixed {
+            display: inline-flex;
+            align-items: center;
+            gap: var(--space-1);
+            font-family: var(--font-mono);
+            font-size: var(--text-xs);
+            font-weight: var(--font-weight-medium);
+            padding: var(--space-1) var(--space-2);
+            padding-left: var(--space-1);
+            border-radius: var(--radius-sm);
+            transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+            vertical-align: middle;
+            width: 130px;
+            min-width: 130px;
+            box-sizing: border-box;
+        }
+
+        .pokemon-badge-fixed:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+        }
+
+        /* Speed bar graph styling */
+        .speed-bar-container {
+            flex: 1;
+            display: flex;
+            align-items: center;
+            gap: var(--space-2);
+            min-width: 0;
+        }
+
+        .speed-bar {
+            height: 8px;
+            background: linear-gradient(90deg, var(--color-emerald), var(--color-electric));
+            border-radius: 4px;
+            transition: width 0.3s ease;
+        }
+
+        .speed-bar-value {
+            font-family: var(--font-mono);
+            font-size: var(--text-base);
+            font-weight: var(--font-weight-semibold);
+            color: var(--color-electric);
+            min-width: 45px;
+            text-align: right;
+        }
+
+        /* Speed tier item with bar graph */
+        .speed-tier-item-bar {
+            display: flex;
+            align-items: center;
+            gap: var(--space-3);
+            padding: var(--space-2) var(--space-3);
+            background: var(--color-bg-surface);
+            border-radius: var(--radius-sm);
+            margin-bottom: var(--space-2);
+        }
+
+        .speed-tier-item-bar .speed-tier-details {
+            font-size: var(--text-xs);
+            color: var(--color-text-tertiary);
+            min-width: 150px;
+            max-width: 200px;
+        }
+
+        /* Speed Diagram Styles */
+        .speed-diagram-container {
+            background: var(--color-bg-surface);
+            border: 1px solid var(--color-border);
+            border-radius: var(--radius-lg);
+            padding: var(--space-6);
+            margin-bottom: var(--space-6);
+            overflow-x: auto;
+        }
+
+        .speed-diagram {
+            position: relative;
+            min-height: 500px;
+            display: grid;
+            grid-template-columns: 50px 1fr 1fr 1fr;
+            gap: 0;
+        }
+
+        .speed-diagram-y-axis {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-between;
+            padding-right: var(--space-2);
+            border-right: 2px solid var(--color-border);
+        }
+
+        .speed-diagram-y-label {
+            font-family: var(--font-mono);
+            font-size: var(--text-xs);
+            color: var(--color-text-secondary);
+            text-align: right;
+        }
+
+        .speed-diagram-column {
+            position: relative;
+            border-right: 1px solid var(--color-border);
+            min-height: 500px;
+        }
+
+        .speed-diagram-column:last-child {
+            border-right: none;
+        }
+
+        .speed-diagram-column-header {
+            text-align: center;
+            font-family: var(--font-mono);
+            font-size: var(--text-sm);
+            font-weight: var(--font-weight-semibold);
+            padding: var(--space-2);
+            background: var(--color-bg-primary);
+            border-bottom: 2px solid var(--color-border);
+            position: sticky;
+            top: 0;
+        }
+
+        .speed-diagram-sprite {
+            position: absolute;
+            cursor: pointer;
+            transition: transform 0.2s ease, z-index 0.2s;
+            z-index: 1;
+        }
+
+        .speed-diagram-sprite:hover {
+            transform: scale(1.3);
+            z-index: 10;
+        }
+
+        .speed-diagram-sprite img {
+            width: 40px;
+            height: 40px;
+        }
+
+        .nature-negative { color: var(--color-sapphire); }
+        .nature-neutral { color: var(--color-text-primary); }
+        .nature-positive { color: var(--color-emerald); }
+
         /* Overview section for narrative content */
         .overview-section {
             background: var(--color-bg-surface);
@@ -517,6 +659,26 @@
                 ${createSprite(name, size)}
                 <span class="sprite-label">${name}</span>
             </div>`;
+        }
+
+        // Helper: Create fixed-width Pokemon badge for speed tiers
+        function createPokemonBadgeFixed(name, showSprite = true) {
+            const key = getPokemonKeyByName(name);
+            const style = getTypeStyle(name);
+            const onclick = key ? `onclick="showPokemonDetail('${key}')"` : '';
+            const spriteHtml = showSprite ? createSprite(name, 28) : '';
+            return `<span class="pokemon-badge-fixed" ${onclick} style="background: ${style.gradient}; color: ${style.textColor}; cursor: ${key ? 'pointer' : 'default'}; text-shadow: ${style.textColor === '#000000' ? 'none' : '1px 1px 2px rgba(0,0,0,0.5)'};">${spriteHtml}<span class="pokemon-badge-name">${name}</span></span>`;
+        }
+
+        // Helper: Create speed bar HTML
+        function createSpeedBar(speed, maxSpeed = 400, minSpeed = 90) {
+            const percentage = Math.min(100, Math.max(0, ((speed - minSpeed) / (maxSpeed - minSpeed)) * 100));
+            return `
+                <div class="speed-bar-container">
+                    <div class="speed-bar" style="width: ${percentage}%;"></div>
+                    <span class="speed-bar-value">${speed}</span>
+                </div>
+            `;
         }
 
         // =========================
@@ -1513,6 +1675,147 @@
             return 'balanced';
         }
 
+        // Render Speed Diagram (Y = speed, X = nature)
+        function renderSpeedDiagram(data) {
+            const benchmarks = data.key_benchmarks || {};
+            const tiers = data.practical_speed_tiers || {};
+
+            // Collect all Pokemon with their speed and nature info
+            const pokemonData = [];
+
+            // From key benchmarks
+            Object.entries(benchmarks).forEach(([speed, info]) => {
+                const natureStr = (info.nature || '').toLowerCase();
+                let natureType = 'neutral';
+                if (natureStr.includes('jolly') || natureStr.includes('timid')) {
+                    natureType = 'positive';
+                } else if (natureStr.includes('adamant') || natureStr.includes('modest') || natureStr.includes('brave') || natureStr.includes('quiet')) {
+                    natureType = 'negative';
+                } else if (natureStr.includes('careful') || natureStr.includes('calm') || natureStr.includes('impish') || natureStr.includes('bold') || natureStr.includes('sassy') || natureStr.includes('relaxed')) {
+                    natureType = 'negative';
+                }
+
+                (info.pokemon || []).forEach(name => {
+                    pokemonData.push({
+                        name,
+                        speed: parseInt(speed),
+                        nature: natureType,
+                        description: info.description
+                    });
+                });
+            });
+
+            // From practical tiers
+            Object.values(tiers).forEach(tier => {
+                (tier.pokemon || []).forEach(p => {
+                    const setStr = (p.set || p.condition || '').toLowerCase();
+                    let natureType = 'neutral';
+                    if (setStr.includes('jolly') || setStr.includes('timid')) {
+                        natureType = 'positive';
+                    } else if (setStr.includes('adamant') || setStr.includes('modest')) {
+                        natureType = 'negative';
+                    } else if (setStr.includes('careful') || setStr.includes('calm') || setStr.includes('impish') || setStr.includes('bold') || setStr.includes('sassy') || setStr.includes('relaxed')) {
+                        natureType = 'negative';
+                    }
+
+                    // Avoid duplicates
+                    const exists = pokemonData.find(pd => pd.name === p.name && pd.speed === p.speed);
+                    if (!exists) {
+                        pokemonData.push({
+                            name: p.name,
+                            speed: p.speed,
+                            nature: natureType,
+                            description: p.set || p.condition || p.note || ''
+                        });
+                    }
+                });
+            });
+
+            // Sort by speed descending
+            pokemonData.sort((a, b) => b.speed - a.speed);
+
+            // Group by nature
+            const byNature = {
+                negative: pokemonData.filter(p => p.nature === 'negative'),
+                neutral: pokemonData.filter(p => p.nature === 'neutral'),
+                positive: pokemonData.filter(p => p.nature === 'positive')
+            };
+
+            // Calculate diagram dimensions
+            const minSpeed = 90;
+            const maxSpeed = 420;
+            const diagramHeight = 600;
+
+            // Helper to calculate Y position (higher speed = higher on diagram)
+            const getYPosition = (speed) => {
+                const percentage = (speed - minSpeed) / (maxSpeed - minSpeed);
+                return diagramHeight - (percentage * (diagramHeight - 60)) - 30; // Leave margin for header
+            };
+
+            // Generate Y-axis labels
+            const yLabels = [400, 350, 300, 250, 200, 150, 100];
+
+            let html = `
+                <div class="card">
+                    <h2>Speed by Nature Diagram</h2>
+                    <p class="text-secondary mb-4">Pokemon positioned by their Speed stat (Y-axis) and whether they use a speed-boosting, neutral, or speed-reducing nature (X-axis). Hover over sprites to see details.</p>
+                    <div class="speed-diagram-container">
+                        <div class="speed-diagram" style="height: ${diagramHeight}px;">
+                            <div class="speed-diagram-y-axis" style="height: ${diagramHeight}px;">
+                                ${yLabels.map(speed => `
+                                    <span class="speed-diagram-y-label" style="position: absolute; top: ${getYPosition(speed) - 8}px; right: 8px;">${speed}</span>
+                                `).join('')}
+                            </div>
+            `;
+
+            // Render each column
+            ['negative', 'neutral', 'positive'].forEach((natureType, colIndex) => {
+                const label = natureType === 'negative' ? 'Speed- Nature' :
+                             natureType === 'neutral' ? 'Neutral Nature' : 'Speed+ Nature';
+                const colorClass = `nature-${natureType}`;
+                const columnPokemon = byNature[natureType];
+
+                html += `
+                    <div class="speed-diagram-column" style="height: ${diagramHeight}px; position: relative;">
+                        <div class="speed-diagram-column-header ${colorClass}">${label}</div>
+                `;
+
+                // Track horizontal positions to avoid overlaps within same speed range
+                const occupiedPositions = {};
+
+                columnPokemon.forEach((p, idx) => {
+                    const yPos = getYPosition(p.speed);
+
+                    // Find an available x position (stagger sprites at similar speeds)
+                    const speedBucket = Math.floor(p.speed / 20);
+                    if (!occupiedPositions[speedBucket]) occupiedPositions[speedBucket] = 0;
+                    const xOffset = (occupiedPositions[speedBucket] % 4) * 45 + 10;
+                    occupiedPositions[speedBucket]++;
+
+                    const key = getPokemonKeyByName(p.name);
+                    const onclick = key ? `onclick="showPokemonDetail('${key}')"` : '';
+
+                    html += `
+                        <div class="speed-diagram-sprite" ${onclick}
+                             style="top: ${yPos}px; left: ${xOffset}px;"
+                             title="${p.name}: ${p.speed} Spe\n${p.description}">
+                            ${createSprite(p.name, 40)}
+                        </div>
+                    `;
+                });
+
+                html += `</div>`;
+            });
+
+            html += `
+                        </div>
+                    </div>
+                </div>
+            `;
+
+            return html;
+        }
+
         // Render speed tiers
         function renderSpeedTiers() {
             const container = document.getElementById('speed-content');
@@ -1523,7 +1826,12 @@
                     <h2>ADV OU Speed Tiers</h2>
                     <p class="text-secondary">${data.speed_tiers_overview?.description || 'Critical speed benchmarks in ADV OU'}</p>
                 </div>
+            `;
 
+            // Speed Diagram (Y = speed, X = nature)
+            html += renderSpeedDiagram(data);
+
+            html += `
                 <div class="card">
                     <h2>Speed Calculation Formulas</h2>
                     <div class="set-card">
@@ -1537,7 +1845,7 @@
                 </div>
             `;
 
-            // Practical Speed Tiers
+            // Practical Speed Tiers with bar graphs
             const tiers = data.practical_speed_tiers || {};
             html += `<div class="card"><h2>Practical Speed Tiers</h2>`;
 
@@ -1545,12 +1853,12 @@
                 html += `
                     <div class="set-card">
                         <h4 style="color: ${getTierColor(tierKey)};">${tier.range} - ${tier.description}</h4>
-                        <div class="speed-tier-list mt-3">
+                        <div class="mt-3">
                             ${tier.pokemon.map(p => `
-                                <div class="speed-tier-item">
-                                    <span class="speed-tier-pokemon">${createPokemonBadge(p.name)}</span>
+                                <div class="speed-tier-item-bar">
+                                    ${createPokemonBadgeFixed(p.name)}
                                     <span class="speed-tier-details">${p.set || p.condition || ''}</span>
-                                    <span class="speed-tier-number">${p.speed}</span>
+                                    ${createSpeedBar(p.speed)}
                                 </div>
                             `).join('')}
                         </div>
@@ -1570,12 +1878,16 @@
                         <div class="set-card">
                             <div class="flex justify-between items-center mb-3">
                                 <h4>${info.description}</h4>
-                                <span class="speed-number">${speed}</span>
                             </div>
-                            <div class="moves-list mb-3">
-                                ${info.pokemon.map(p => createPokemonBadge(p)).join('')}
+                            <div class="mb-3">
+                                ${info.pokemon.map(p => `
+                                    <div class="speed-tier-item-bar">
+                                        ${createPokemonBadgeFixed(p)}
+                                        <span class="speed-tier-details">${info.nature} / ${info.evs}</span>
+                                        ${createSpeedBar(parseInt(speed))}
+                                    </div>
+                                `).join('')}
                             </div>
-                            <p class="text-sm"><strong>Nature:</strong> ${info.nature} | <strong>EVs:</strong> ${info.evs}</p>
                             <p class="text-secondary">${info.significance}</p>
                             ${info.note ? `<p class="text-sm text-sapphire mt-2" style="font-style: italic;">${info.note}</p>` : ''}
                         </div>
@@ -1591,13 +1903,14 @@
                 html += `
                     <div class="set-card">
                         <h4>Dragon Dance / Salac Berry (+1 Speed)</h4>
-                        <p class="text-secondary">${boosted.dragon_dance_plus_one.description}</p>
-                        <p><strong>Formula:</strong> ${boosted.dragon_dance_plus_one.formula}</p>
-                        <div class="speed-tier-list mt-3">
+                        <p class="text-secondary mb-2">${boosted.dragon_dance_plus_one.description}</p>
+                        <p class="mb-3"><strong>Formula:</strong> ${boosted.dragon_dance_plus_one.formula}</p>
+                        <div class="mt-3">
                             ${Object.entries(boosted.dragon_dance_plus_one.common_threats || {}).map(([speed, info]) => `
-                                <div class="speed-tier-item">
-                                    <span>${createPokemonBadge(info.pokemon)} <span class="text-secondary text-sm">(${info.unboosted} unboosted)</span></span>
-                                    <span class="speed-number ml-auto">+1: ${speed}</span>
+                                <div class="speed-tier-item-bar">
+                                    ${createPokemonBadgeFixed(info.pokemon)}
+                                    <span class="speed-tier-details">${info.unboosted} unboosted</span>
+                                    ${createSpeedBar(parseInt(speed), 500)}
                                 </div>
                             `).join('')}
                         </div>
@@ -1609,13 +1922,14 @@
                 html += `
                     <div class="set-card">
                         <h4>Agility (+2 Speed)</h4>
-                        <p class="text-secondary">${boosted.agility_plus_two.description}</p>
-                        <p><strong>Formula:</strong> ${boosted.agility_plus_two.formula}</p>
-                        <div class="speed-tier-list mt-3">
+                        <p class="text-secondary mb-2">${boosted.agility_plus_two.description}</p>
+                        <p class="mb-3"><strong>Formula:</strong> ${boosted.agility_plus_two.formula}</p>
+                        <div class="mt-3">
                             ${Object.entries(boosted.agility_plus_two.common_threats || {}).map(([speed, info]) => `
-                                <div class="speed-tier-item">
-                                    <span>${Array.isArray(info.pokemon) ? info.pokemon.map(p => createPokemonBadge(p)).join(' ') : createPokemonBadge(info.pokemon)} <span class="text-secondary text-sm">(${info.unboosted || ''} unboosted)</span></span>
-                                    <span class="speed-number ml-auto">+2: ${speed}</span>
+                                <div class="speed-tier-item-bar">
+                                    ${Array.isArray(info.pokemon) ? info.pokemon.map(p => createPokemonBadgeFixed(p)).join('') : createPokemonBadgeFixed(info.pokemon)}
+                                    <span class="speed-tier-details">${info.unboosted || ''} unboosted</span>
+                                    ${createSpeedBar(parseInt(speed), 500)}
                                 </div>
                             `).join('')}
                         </div>
@@ -1627,14 +1941,14 @@
                 html += `
                     <div class="set-card">
                         <h4>Swift Swim (Rain)</h4>
-                        <p class="text-secondary">${boosted.swift_swim_rain.description}</p>
-                        <p><strong>Mechanics:</strong> ${boosted.swift_swim_rain.mechanics}</p>
-                        <div class="speed-tier-list mt-3">
+                        <p class="text-secondary mb-2">${boosted.swift_swim_rain.description}</p>
+                        <p class="mb-3"><strong>Mechanics:</strong> ${boosted.swift_swim_rain.mechanics}</p>
+                        <div class="mt-3">
                             ${Object.entries(boosted.swift_swim_rain.common_users || {}).map(([key, info]) => `
-                                <div class="speed-tier-item">
-                                    ${createPokemonBadge(info.pokemon)}
-                                    <span class="text-secondary flex-1">${info.significance}</span>
-                                    ${info.boosted ? `<span class="speed-number">Rain: ${info.boosted}</span>` : ''}
+                                <div class="speed-tier-item-bar">
+                                    ${createPokemonBadgeFixed(info.pokemon)}
+                                    <span class="speed-tier-details">${info.significance}</span>
+                                    ${info.boosted ? createSpeedBar(parseInt(info.boosted), 500) : '<div class="speed-bar-container"></div>'}
                                 </div>
                             `).join('')}
                         </div>
@@ -1652,9 +1966,12 @@
                     <p class="text-secondary mb-4">${creep.description || ''}</p>
                     ${Object.entries(creep.targets || {}).map(([key, target]) => `
                         <div class="set-card">
-                            <div class="flex justify-between items-center mb-3">
+                            <div class="mb-3">
                                 <h4>${key.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase())}</h4>
-                                <span class="speed-number">${target.target_speed}</span>
+                                <div class="speed-tier-item-bar mt-2">
+                                    <span class="speed-tier-details" style="min-width: 120px;">Target Speed</span>
+                                    ${createSpeedBar(target.target_speed)}
+                                </div>
                             </div>
                             <p>${target.reasoning}</p>
                             ${target.common_users ? `<p class="mt-2"><strong>Common Users:</strong> ${target.common_users.join(', ')}</p>` : ''}


### PR DESCRIPTION
- Add fixed-width Pokemon badges (130px) for consistent alignment
- Add horizontal speed bar graphs showing relative speed values
- Add Speed by Nature diagram (Y=speed, X=positive/neutral/negative nature)
- Sprites positioned on diagram by their speed stat and nature type
- Update Practical Speed Tiers with bar graph visualization
- Update Key Benchmarks with bar graph styling
- Update Boosted Speeds section with bar graphs
- Update Speed Creep Guide with target speed bars